### PR TITLE
Removed fiber

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-nuxt": "^2.0.0",
     "eslint-plugin-vue": "^7.17.0",
-    "fibers": "^5.0.0",
     "prettier": "^2.3.2",
     "sass": "^1.43.4",
     "sass-loader": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,13 +7167,6 @@ fetch-blob@^3.1.2:
   dependencies:
     web-streams-polyfill "^3.0.3"
 
-fibers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
-  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
-  dependencies:
-    detect-libc "^1.0.3"
-
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"


### PR DESCRIPTION
Fibers is not supported on nodejs v16.x or higher.
This PR removes it.